### PR TITLE
Add main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gb-tracker-client",
   "version": "3.7.2",
   "description": "GroupBy client-side event tracker",
+  "main": "index.js",
   "keywords": [
     "groupby",
     "tracker",


### PR DESCRIPTION
Add a `main` entry in package.json to fix linting errors when using this package in other projects. In short, `eslint` fails to find this package's exports without a `main` entry.