### PR TITLE
WIS-2660 | Add first-party subdomain support to gb-tracker-client cookie tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the CDN `<script>` to each page, above where the tracker is instantiated and
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Document</title>
-    <script src="http://cdn.groupbycloud.com/gb-tracker-client-3.min.js"></script>
+    <script src="http://cdn.groupbycloud.com/gb-tracker-client-4.min.js"></script>
     <script>
         var tracker = new GbTracker('customer_id', 'area');
         tracker.autoSetVisitor();

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ const a: AddToCartEvent = { ... };
 tracker.sendAddToCartEvent(a);
 ```
 
+## Options
+
+The constructor for the tracker client has a third, optional parameter for providing options:
+
+```typescript
+const tracker = new GbTracker('customer_id', 'area', {
+    overrideUrl: '<some_url>' // Optional, overrides the URL the beacon is sent to. Useful for testing.
+});
+```
+
 ## More Usage Details
 
 See the docs for more detailed information about implementing beacons:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.13.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@groupby/beacon-models": "^2.0.4",
@@ -24,7 +24,7 @@
         "@types/glob": "^7.1.3",
         "@types/jsdom": "^16.2.3",
         "@types/lz-string": "^1.3.34",
-        "@types/mocha": "^7.0.2",
+        "@types/mocha": "^9.0.0",
         "@types/node": "^14.0.27",
         "@types/query-string": "^5.1.0",
         "@types/stringify-object": "^3.3.0",
@@ -371,9 +371,9 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
+      "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -7851,9 +7851,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
+      "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
       "dev": true
     },
     "@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.13.0",
+      "name": "gb-tracker-client",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "@groupby/beacon-models": "^2.0.4",
         "cookies-js": "^1.2.3",
         "cuid": "^2.1.8",
         "deep-diff": "^1.0.2",
@@ -278,17 +278,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "node_modules/@groupby/beacon-models": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@groupby/beacon-models/-/beacon-models-2.0.4.tgz",
-      "integrity": "sha512-ZZr1XD/xobuFZ073KT5m2YDXFCv3ppzDwvvvJKwOnTeiJGjx9NpK5xwdxltU0WeBJxuPIt1YCVXORR8LmZUdgg==",
-      "dependencies": {
-        "@types/lodash": "^4.14.123",
-        "lodash": "^4.17.11",
-        "moment": "^2.22.2",
-        "regexpu-core": "^4.2.0"
-      }
-    },
     "node_modules/@types/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
@@ -346,11 +335,6 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true,
       "optional": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.154",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.154.tgz",
-      "integrity": "sha512-VoDZIJmg3P8vPEnTldLvgA+q7RkIbVkbYX4k0cAVFzGAOQwUehVgRHgIr2/wepwivDst/rVRqaiBSjCXRnoWwQ=="
     },
     "node_modules/@types/lz-string": {
       "version": "1.3.34",
@@ -3891,14 +3875,6 @@
       "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
       "dev": true
     },
-    "node_modules/jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      }
-    },
     "node_modules/json-diff": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.4.tgz",
@@ -4495,6 +4471,7 @@
       "version": "2.27.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
       "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -5388,22 +5365,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
-    },
-    "node_modules/regenerate-unicode-properties": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-      "dependencies": {
-        "regenerate": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5415,38 +5376,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regexpu-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
-      "dependencies": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.2.0",
-        "regjsgen": "^0.5.1",
-        "regjsparser": "^0.6.4",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/regjsgen": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
-    },
-    "node_modules/regjsparser": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
-      "dependencies": {
-        "jsesc": "~0.5.0"
-      },
-      "bin": {
-        "regjsparser": "bin/parser"
       }
     },
     "node_modules/remove-trailing-separator": {
@@ -6711,42 +6640,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dependencies": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-property-aliases-ecmascript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -7758,17 +7651,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@groupby/beacon-models": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@groupby/beacon-models/-/beacon-models-2.0.4.tgz",
-      "integrity": "sha512-ZZr1XD/xobuFZ073KT5m2YDXFCv3ppzDwvvvJKwOnTeiJGjx9NpK5xwdxltU0WeBJxuPIt1YCVXORR8LmZUdgg==",
-      "requires": {
-        "@types/lodash": "^4.14.123",
-        "lodash": "^4.17.11",
-        "moment": "^2.22.2",
-        "regexpu-core": "^4.2.0"
-      }
-    },
     "@types/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
@@ -7826,11 +7708,6 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true,
       "optional": true
-    },
-    "@types/lodash": {
-      "version": "4.14.154",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.154.tgz",
-      "integrity": "sha512-VoDZIJmg3P8vPEnTldLvgA+q7RkIbVkbYX4k0cAVFzGAOQwUehVgRHgIr2/wepwivDst/rVRqaiBSjCXRnoWwQ=="
     },
     "@types/lz-string": {
       "version": "1.3.34",
@@ -10867,11 +10744,6 @@
       "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
       "dev": true
     },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-    },
     "json-diff": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.4.tgz",
@@ -11358,7 +11230,8 @@
     "moment": {
       "version": "2.27.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+      "dev": true
     },
     "morgan": {
       "version": "1.10.0",
@@ -12120,19 +11993,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
-    },
-    "regenerate-unicode-properties": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-      "requires": {
-        "regenerate": "^1.4.0"
-      }
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -12141,32 +12001,6 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
-      }
-    },
-    "regexpu-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
-      "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.2.0",
-        "regjsgen": "^0.5.1",
-        "regjsparser": "^0.6.4",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.2.0"
-      }
-    },
-    "regjsgen": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
-    },
-    "regjsparser": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
-      "requires": {
-        "jsesc": "~0.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -13226,30 +13060,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
-    },
-    "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
-    },
-    "unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      }
-    },
-    "unicode-match-property-value-ecmascript": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
-    },
-    "unicode-property-aliases-ecmascript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gb-tracker-client",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gb-tracker-client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "types": "index.d.ts",
   "dependencies": {
-    "@groupby/beacon-models": "^2.0.4",
     "cookies-js": "^1.2.3",
     "cuid": "^2.1.8",
     "deep-diff": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gb-tracker-client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "GroupBy client-side event tracker",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gb-tracker-client",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "GroupBy client-side event tracker",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/glob": "^7.1.3",
     "@types/jsdom": "^16.2.3",
     "@types/lz-string": "^1.3.34",
-    "@types/mocha": "^7.0.2",
+    "@types/mocha": "^9.0.0",
     "@types/node": "^14.0.27",
     "@types/query-string": "^5.1.0",
     "@types/stringify-object": "^3.3.0",

--- a/src/core.ts
+++ b/src/core.ts
@@ -106,10 +106,14 @@ export interface TrackerCoreFactory {
     (schemas: Schemas, sanitizeEvent: SanitizeEventFn): TrackerFactory;
 }
 
+interface Options {
+    overrideUrl?: string;
+}
+
 export interface TrackerFactory {
     VERSION: string;
-    new(customerId: string, area?: string, overridePixelUrl?: string | null): Tracker;
-    (customerId: string, area?: string, overridePixelUrl?: string | null): Tracker;
+    new(customerId: string, area?: string, options?: Options | null): Tracker;
+    (customerId: string, area?: string, options?: Options | null): Tracker;
 }
 
 export interface TrackerInternals {
@@ -168,7 +172,7 @@ export interface Tracker {
 }
 
 function TrackerCore(schemas: Schemas, sanitizeEvent: SanitizeEventFn): TrackerFactory {
-    function TrackerCtr(customerId: string, area: string = 'Production', overridePixelUrl?: string): Tracker {
+    function TrackerCtr(customerId: string, area: string = 'Production', options?: Options): Tracker {
         // Setting up customer
         if (typeof customerId !== 'string' || customerId.length === 0) {
             throw new Error('customerId must be a string with length');
@@ -203,7 +207,7 @@ function TrackerCore(schemas: Schemas, sanitizeEvent: SanitizeEventFn): TrackerF
             INVALID_EVENT_CALLBACK: undefined,
             STRICT_MODE: false,
             WARNINGS_DISABLED: false,
-            OVERRIDEN_PIXEL_URL: overridePixelUrl,
+            OVERRIDEN_PIXEL_URL: options?.overrideUrl,
 
             VISITOR_SETTINGS_SOURCE: undefined,
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,10 +6,12 @@
  * non-GroupBy Search, or custom solutions created with help from a GroupBy
  * Customer's TC on the Customer Success team.
  */
-type Metadata = {
-    key: string,
-    value: string
-}[];
+interface MetadataItem {
+    key: string;
+    value: string;
+}
+
+type Metadata = MetadataItem[];
 
 interface AutoMoreRefinementsPartial {
     id: string;
@@ -173,7 +175,7 @@ interface DirectSearchPartial {
     originalRequest?: SearchQuery;
 }
 
-interface Product {
+export interface Product {
     category?: string;
     collection: string;
     title: string;
@@ -199,7 +201,7 @@ export interface SendableOrigin {
 /**
  * Used for A/B testing experiments.
  */
-interface Experiment {
+export interface Experiment {
     experimentId: string;
     experimentVariant: string;
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -175,7 +175,7 @@ interface DirectSearchPartial {
     originalRequest?: SearchQuery;
 }
 
-export interface Product {
+interface Product {
     category?: string;
     collection: string;
     title: string;
@@ -201,7 +201,7 @@ export interface SendableOrigin {
 /**
  * Used for A/B testing experiments.
  */
-export interface Experiment {
+interface Experiment {
     experimentId: string;
     experimentVariant: string;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -47,3 +47,23 @@ export function startsWithOneOf(target: string, array: string[]): boolean {
 
     return false;
 }
+
+/**
+ * When we set the visitor ID cookie, we want to set it on the apex domain, not the specific domain. This allows all
+ * domains the customer has associated with the apex domaint to share a visitor ID value. We consider this to not
+ * violate privacy because presumably, any subdomains are owned by the same customer that owns the apex domain. They
+ * presumably already have the ability to track shoppers accross their websites. We're matching that capability, but
+ * going no further. For example, we aren't tracking shoppers accross different apex domains.
+ * @param window An object conforming the Window interface of web browsers.
+ */
+export function getApexDomain(window: Window): string {
+    const host = window.location.hostname;
+
+    if (host.indexOf('.') < 0) {
+        // No . so do no split.
+        return host;
+    }
+
+    const split = host.split('.');
+    return `${split[split.length - 2]}.${split[split.length - 1]}`;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -50,7 +50,7 @@ export function startsWithOneOf(target: string, array: string[]): boolean {
 
 /**
  * When we set the visitor ID cookie, we want to set it on the apex domain, not the specific domain. This allows all
- * domains the customer has associated with the apex domaint to share a visitor ID value. We consider this to not
+ * domains the customer has associated with the apex domain to share a visitor ID value. We consider this to not
  * violate privacy because presumably, any subdomains are owned by the same customer that owns the apex domain. They
  * presumably already have the ability to track shoppers accross their websites. We're matching that capability, but
  * going no further. For example, we aren't tracking shoppers accross different apex domains.

--- a/test-integration/apps/sites/addToCart.template.html
+++ b/test-integration/apps/sites/addToCart.template.html
@@ -9,7 +9,9 @@
     <script src="{{gbTrackerClientSrc}}"></script>
     <script>
         // call autoSetVisitor before using the tracker instance
-        var gbTracker = new GbTracker('testcustomer', 'testarea', 'http://localhost:{{beaconConsumerPort}}');
+        var gbTracker = new GbTracker('testcustomer', 'testarea', {
+            overrideUrl: 'http://localhost:{{beaconConsumerPort}}',
+        });
         gbTracker.autoSetVisitor();
 
         gbTracker.sendAddToCartEvent({

--- a/test-integration/apps/sites/autoSearch.template.html
+++ b/test-integration/apps/sites/autoSearch.template.html
@@ -9,7 +9,9 @@
     <script src="{{gbTrackerClientSrc}}"></script>
     <script>
         // call autoSetVisitor before using the tracker instance
-        var gbTracker = new GbTracker('testcustomer', 'testarea', 'http://localhost:{{beaconConsumerPort}}');
+        var gbTracker = new GbTracker('testcustomer', 'testarea', {
+            overrideUrl: 'http://localhost:{{beaconConsumerPort}}',
+        });
         gbTracker.autoSetVisitor();
 
         gbTracker.sendAutoSearchEvent({

--- a/test-integration/apps/sites/impression.template.html
+++ b/test-integration/apps/sites/impression.template.html
@@ -9,7 +9,9 @@
     <script src="{{gbTrackerClientSrc}}"></script>
     <script>
         // call autoSetVisitor before using the tracker instance
-        var gbTracker = new GbTracker('testcustomer', 'testarea', 'http://localhost:{{beaconConsumerPort}}');
+        var gbTracker = new GbTracker('testcustomer', 'testarea', {
+            overrideUrl: 'http://localhost:{{beaconConsumerPort}}',
+        });
         gbTracker.autoSetVisitor();
 
         gbTracker.sendImpressionEvent({

--- a/test-integration/apps/sites/order.template.html
+++ b/test-integration/apps/sites/order.template.html
@@ -9,7 +9,9 @@
     <script src="{{gbTrackerClientSrc}}"></script>
     <script>
         // call autoSetVisitor before using the tracker instance
-        var gbTracker = new GbTracker('testcustomer', 'testarea', 'http://localhost:{{beaconConsumerPort}}');
+        var gbTracker = new GbTracker('testcustomer', 'testarea', {
+            overrideUrl: 'http://localhost:{{beaconConsumerPort}}',
+        });
         gbTracker.autoSetVisitor();
 
         gbTracker.sendOrderEvent({

--- a/test-integration/apps/sites/removeFromCart.template.html
+++ b/test-integration/apps/sites/removeFromCart.template.html
@@ -9,7 +9,9 @@
     <script src="{{gbTrackerClientSrc}}"></script>
     <script>
         // call autoSetVisitor before using the tracker instance
-        var gbTracker = new GbTracker('testcustomer', 'testarea', 'http://localhost:{{beaconConsumerPort}}');
+        var gbTracker = new GbTracker('testcustomer', 'testarea', {
+            overrideUrl: 'http://localhost:{{beaconConsumerPort}}',
+        });
         gbTracker.autoSetVisitor();
 
         gbTracker.sendRemoveFromCartEvent({

--- a/test-integration/apps/sites/search.template.html
+++ b/test-integration/apps/sites/search.template.html
@@ -9,7 +9,9 @@
     <script src="{{gbTrackerClientSrc}}"></script>
     <script>
         // call autoSetVisitor before using the tracker instance
-        var gbTracker = new GbTracker('testcustomer', 'testarea', 'http://localhost:{{beaconConsumerPort}}');
+        var gbTracker = new GbTracker('testcustomer', 'testarea', {
+            overrideUrl: 'http://localhost:{{beaconConsumerPort}}',
+        });
         gbTracker.autoSetVisitor();
 
         gbTracker.sendSearchEvent({

--- a/test-integration/apps/sites/viewProduct.template.html
+++ b/test-integration/apps/sites/viewProduct.template.html
@@ -9,7 +9,9 @@
     <script src="{{gbTrackerClientSrc}}"></script>
     <script>
         // call autoSetVisitor before using the tracker instance
-        var gbTracker = new GbTracker('testcustomer', 'testarea', 'http://localhost:{{beaconConsumerPort}}');
+        var gbTracker = new GbTracker('testcustomer', 'testarea', {
+            overrideUrl: 'http://localhost:{{beaconConsumerPort}}',
+        });
         gbTracker.autoSetVisitor();
 
         gbTracker.sendViewProductEvent({

--- a/test/gb-tracker-core.spec.ts
+++ b/test/gb-tracker-core.spec.ts
@@ -101,7 +101,7 @@ describe('gb-tracker-core tests', () => {
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
 
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
     CookiesLib._document = window.document;
 
     expect(CookiesLib.get(gbTrackerCore.__getInternals().VISITOR_COOKIE_KEY)).to.be.undefined;
@@ -131,7 +131,7 @@ describe('gb-tracker-core tests', () => {
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
 
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
     CookiesLib._document = window.document;
 
     expect(CookiesLib.get(gbTrackerCore.__getInternals().VISITOR_COOKIE_KEY)).to.be.undefined;
@@ -169,7 +169,7 @@ describe('gb-tracker-core tests', () => {
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
 
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
     CookiesLib._document = window.document;
 
     expect(CookiesLib.get(gbTrackerCore.__getInternals().VISITOR_COOKIE_KEY)).to.be.undefined;
@@ -207,7 +207,7 @@ describe('gb-tracker-core tests', () => {
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
 
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
     CookiesLib._document = window.document;
 
     expect(CookiesLib.get(gbTrackerCore.__getInternals().VISITOR_COOKIE_KEY)).to.be.undefined;
@@ -238,7 +238,7 @@ describe('gb-tracker-core tests', () => {
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
 
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
     CookiesLib._document = window.document;
 
     gbTrackerCore.setVisitor(1 as any, 1 as any);
@@ -252,7 +252,7 @@ describe('gb-tracker-core tests', () => {
     const cookieJar = new jsdom.CookieJar();
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
 
     const visitorCookieKey = gbTrackerCore.__getInternals().VISITOR_COOKIE_KEY;
 
@@ -276,7 +276,7 @@ describe('gb-tracker-core tests', () => {
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
     const internals = gbTrackerCore.__getInternals();
     internals.WINDOW = window as unknown as Window;
-    const CookiesLib = internals.COOKIES_LIB;
+    const CookiesLib = internals.COOKIES_LIB as any;
 
     const visitorCookieKey = internals.VISITOR_COOKIE_KEY;
 
@@ -300,7 +300,7 @@ describe('gb-tracker-core tests', () => {
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
     const internals = gbTrackerCore.__getInternals();
     internals.WINDOW = window as unknown as Window;
-    const CookiesLib = internals.COOKIES_LIB;
+    const CookiesLib = internals.COOKIES_LIB as any;
 
     CookiesLib._document = window.document;
 
@@ -324,7 +324,7 @@ describe('gb-tracker-core tests', () => {
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
     const internals = gbTrackerCore.__getInternals();
     internals.WINDOW = window as unknown as Window;
-    const CookiesLib = internals.COOKIES_LIB;
+    const CookiesLib = internals.COOKIES_LIB as any;
 
     CookiesLib._document = window.document;
     CookiesLib.set(internals.VISITOR_COOKIE_KEY, 'abc123');
@@ -344,7 +344,7 @@ describe('gb-tracker-core tests', () => {
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
 
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
     CookiesLib._document = window.document;
 
     gbTrackerCore.autoSetVisitor();
@@ -360,7 +360,7 @@ describe('gb-tracker-core tests', () => {
     const window = new jsdom.JSDOM(undefined, { cookieJar }).window;
 
     const gbTrackerCore = new GbTracker('testcustomer', 'area');
-    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB;
+    const CookiesLib = gbTrackerCore.__getInternals().COOKIES_LIB as any;
     CookiesLib._document = window.document;
 
     expect(CookiesLib.get(gbTrackerCore.__getInternals().VISITOR_COOKIE_KEY)).to.be.undefined;

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -58,4 +58,51 @@ describe('utils tests', () => {
       expect(utils.getUnique(someArray)).to.eql(['this', 'that', 'another', 'something']);
     });
   });
+
+  describe('getApexDomain', () => {
+    it('returns the appropriate value given a certain input (test table style)', () => {
+      interface Input {
+        location: {
+          hostname: string
+        }
+      }
+
+      interface TestCase {
+        input: Input;
+        expected: string;
+      }
+
+      const testCases: TestCase[] = [
+        {
+          input: { location: { hostname: 'example.com' } },
+          expected: 'example.com',
+        },
+        {
+          input: { location: { hostname: 'www.example.com' } },
+          expected: 'example.com',
+        },
+        {
+          input: { location: { hostname: 'sub.example.com' } },
+          expected: 'example.com',
+        },
+        {
+          input: { location: { hostname: 'sub1.sub2.example.com' } },
+          expected: 'example.com',
+        },
+        {
+          input: { location: { hostname: 'example.net' } },
+          expected: 'example.net',
+        },
+        {
+          input: { location: { hostname: 'localhost' } },
+          expected: 'localhost',
+        },
+      ];
+      const sut = utils.getApexDomain;
+
+      testCases.forEach(testCase => {
+        expect(sut(testCase.input as Window)).to.eql(testCase.expected);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Changes visitor ID cookie setting to use the apex domain when the hostname is detected to be a domain (aka not localhost). Requires testing by using on sites deployed to two domains.