### PR TITLE
ci(ANA-1233): Pin version of Ubuntu runner to 20.04

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
[ANA-1233](https://groupby.atlassian.net/browse/ANA-1233)

This fixes issues with the integration tests timing out by pinning the version of the Ubuntu runner to 20.04

GitHub updated the `ubuntu-latest` image, currently with 22.04, from `20230517.1` to `20230604.1`. It is unclear what difference between these two versions caused the failures, but downgrading to Ubuntu 20.04 seems to prevent the failures.

[ANA-1233]: https://groupby.atlassian.net/browse/ANA-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ