### PR TITLE
S4R-9341 | update gb tracker to support conversational origin

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,11 +12,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
     - run: npm ci

--- a/README.md
+++ b/README.md
@@ -118,6 +118,35 @@ For example, if a shopper performed the following events, the visitor ID `abc` w
 - Waits a while, but less than a year, during which time you upgrade to version 5.
 - Visits the site again, clicks their cart (at which point version 5 replaces the visitor ID `bcd` with `abc`), and completes the purchase.
 
+## Conversational Commerce origin (new)
+
+To attribute analytics for Conversational Commerce correctly, the AutoSearch event now supports a new origin flag: `origin.conversation`.
+
+Example:
+
+```typescript
+import GbTracker from 'gb-tracker-client';
+import { AutoSearchEvent } from 'gb-tracker-client/models';
+
+const tracker = new GbTracker('customer_id', 'area');
+tracker.autoSetVisitor();
+
+const event: AutoSearchEvent = {
+  search: {
+    id: 'response_12345',
+    origin: { conversation: true }
+  }
+};
+
+tracker.sendAutoSearchEvent(event);
+```
+
+Notes:
+- You do not need to send a separate direct search when using AutoSearch for CC; set `origin.conversation=true` and include the CC response ID in `search.id`.
+- Other origin flags (sayt, search, etc.) remain supported; only set the one that applies to the given event.
+
+See also docs/event-types.md for more examples.
+
 ## More Usage Details
 
 See the docs for more detailed information about implementing beacons:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "gb-tracker-client",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.4.0",
+      "name": "gb-tracker-client",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
         "cookies-js": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gb-tracker-client",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "GroupBy client-side event tracker",
   "main": "index.js",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ namespace GbTracker {
         autosearch?: boolean;
         navigation?: boolean;
         collectionSwitcher?: boolean;
+        conversation?: boolean;
     }
 
     export type SanitizeEventFn = (event: AnySendableEvent, schema?: any) => any;

--- a/src/models.ts
+++ b/src/models.ts
@@ -196,6 +196,7 @@ export interface SendableOrigin {
     autosearch?: boolean;
     navigation?: boolean;
     collectionSwitcher?: boolean;
+    conversation?: boolean;
 }
 
 /**

--- a/src/schemas/autoSearch.ts
+++ b/src/schemas/autoSearch.ts
@@ -174,6 +174,11 @@ export default {
                 type: 'boolean',
                 optional: false,
                 def: false
+              },
+              conversation: {
+                type: 'boolean',
+                optional: false,
+                def: false
               }
             }
           },

--- a/test-integration/index.spec.js
+++ b/test-integration/index.spec.js
@@ -68,8 +68,16 @@ async function startServersAndBrowser() {
     closables.push(siteAppServer);
 
 
+    const ciArgs = process.env.CI ? [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-gpu'
+    ] : [];
+
     const browser = await puppeteer.launch({
         headless: true,
+        args: ciArgs,
         env: {
             TZ: 'UTC',
             ...process.env,
@@ -83,6 +91,9 @@ async function startServersAndBrowser() {
     // is run, since it grabs the latest Chromium binary each time.
     // Therefore, we manually set user agent version to something known.
     await page.setUserAgent('headlesschrome');
+
+    // Make navigation timeout align with our mocha timeout
+    try { page.setDefaultNavigationTimeout(TIMEOUT_MS); } catch (e) { /* old puppeteer may not support */ }
 
     return page;
 }
@@ -123,6 +134,9 @@ async function visitSiteAndAssert(page, expectedReceivedBeacon) {
     expect(receivedBeacon.visit.generated).to.not.be.undefined;
     expect(receivedBeacon.visit.generated).to.be.a('object');
 
+    expect(receivedBeacon.visit.generated.timezoneOffset).to.not.be.undefined;
+    expect(receivedBeacon.visit.generated.timezoneOffset).to.be.a('number');
+
     expect(receivedBeacon.visit.generated.localTime).to.not.be.undefined;
     expect(receivedBeacon.visit.generated.localTime).to.be.a('string');
     // invalid ISO8601 date strings result in an error when parsed with
@@ -131,6 +145,9 @@ async function visitSiteAndAssert(page, expectedReceivedBeacon) {
     const d = new Date(localTime);
     expect(d).to.be.a('Date');
     expect(d.toString()).not.eql('Invalid Date');
+
+    expect(Number.isFinite(receivedBeacon.visit.generated.timezoneOffset)).to.be.true;
+    expectedReceivedBeacon.visit.generated.timezoneOffset = receivedBeacon.visit.generated.timezoneOffset;
 
     // Delete nondeterministic properties and assert on rest of beacon.
     delete receivedBeacon.clientVersion.raw;
@@ -230,6 +247,7 @@ describe('gb-tracker-client, running in a web browser', () => {
                     recommendations: false,
                     sayt: false,
                     search: true,
+                    conversation: false,
                 },
             },
         };

--- a/test/events/autoSearch.spec.ts
+++ b/test/events/autoSearch.spec.ts
@@ -55,6 +55,7 @@ describe('autoSearch tests', () => {
           autosearch: false,
           navigation: false,
           collectionSwitcher: false,
+          conversation: false,
         },
       });
 
@@ -68,6 +69,52 @@ describe('autoSearch tests', () => {
     };
 
     gbTrackerCore.setVisitor(expectedEvent.visit.customerData.visitorId, expectedEvent.visit.customerData.sessionId);
+
+    gbTrackerCore.sendAutoSearchEvent({
+      search: expectedEvent.search,
+    });
+  });
+
+  it('should propagate conversation origin flag', (done) => {
+    const expectedEvent = {
+      search: {
+        id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        origin: {
+          conversation: true,
+        },
+      },
+      customer: {
+        id: 'testcustomer',
+        area: 'area',
+      },
+    };
+
+    const gbTrackerCore = new GbTrackerCore(expectedEvent.customer.id, expectedEvent.customer.area);
+
+    gbTrackerCore.__getInternals().sendEvent = (event: any) => {
+
+      expect(event.search).to.eql({
+        ...expectedEvent.search,
+        origin: {
+          dym: false,
+          sayt: false,
+          search: false,
+          recommendations: false,
+          autosearch: false,
+          navigation: false,
+          collectionSwitcher: false,
+          conversation: true,
+        },
+      });
+
+      done();
+    };
+
+    gbTrackerCore.setVisitor('visitor', 'session');
+
+    gbTrackerCore.setInvalidEventCallback(() => {
+      done('fail');
+    });
 
     gbTrackerCore.sendAutoSearchEvent({
       search: expectedEvent.search,


### PR DESCRIPTION
Adds support for tracking Conversational Commerce events by introducing the `origin.conversation` flag to the AutoSearch event.

This allows for accurate attribution of analytics data for Conversational Commerce interactions. Includes documentation updates and tests.

Relates to S4R-9341